### PR TITLE
Avoid strict xml parsing of translation API

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -4,7 +4,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_DEEPL_TRANSLATOR_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_DEEPL_TRANSLATOR_VERSION', '1.1.6' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_DEEPL_TRANSLATOR_VERSION', '1.1.7' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()->register( 'deepl-translator', static function () {
 	$GLOBALS['wgServiceWiringFiles'][] = __DIR__ . '/ServiceWiring.php';

--- a/src/DeepLTranslator.php
+++ b/src/DeepLTranslator.php
@@ -110,7 +110,7 @@ class DeepLTranslator {
 			static::PARAM_SOURCE_LANG => $sourceLang,
 			static::PARAM_TARGET_LANG => $targetLang,
 			static::PARAM_TEXT => $text,
-			static::PARAM_TAG_HANDLING => 'xml',
+			static::PARAM_TAG_HANDLING => 'html',
 			static::PARAM_IGNORE_TAGS => 'deepl:ignore,translation:ignore'
 		];
 	}


### PR DESCRIPTION
When v2 handling of DeepL translate API is used, html tag_handling tolerates not strictly valid XML input, which is often the case for wiki page inputs.

ERM48523

[5.1.x]